### PR TITLE
Fix client websocket reset of connection

### DIFF
--- a/client/debian/additional_files/clapshot+htadmin.nginx.conf
+++ b/client/debian/additional_files/clapshot+htadmin.nginx.conf
@@ -37,8 +37,8 @@ server {
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 			proxy_set_header Host $host;
-			proxy_read_timeout 600s;
-			proxy_send_timeout 600s;
+			proxy_read_timeout 2h;
+			proxy_send_timeout 2h;
 
 			# Pass authenticated username to backend
 			proxy_set_header X-Remote-User-Id $remote_user;

--- a/client/debian/additional_files/clapshot+htadmin.nginx.conf
+++ b/client/debian/additional_files/clapshot+htadmin.nginx.conf
@@ -37,6 +37,8 @@ server {
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 			proxy_set_header Host $host;
+			proxy_read_timeout 600s;
+			proxy_send_timeout 600s;
 
 			# Pass authenticated username to backend
 			proxy_set_header X-Remote-User-Id $remote_user;

--- a/client/debian/additional_files/clapshot.nginx.conf
+++ b/client/debian/additional_files/clapshot.nginx.conf
@@ -47,6 +47,8 @@ server {
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 			proxy_set_header Host $host;
+			proxy_read_timeout 600s;
+			proxy_send_timeout 600s;
 
 			# Pass authenticated username to backend
 			proxy_set_header X-Remote-User-Id $remote_user;

--- a/client/debian/additional_files/clapshot.nginx.conf
+++ b/client/debian/additional_files/clapshot.nginx.conf
@@ -47,8 +47,8 @@ server {
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";
 			proxy_set_header Host $host;
-			proxy_read_timeout 600s;
-			proxy_send_timeout 600s;
+			proxy_read_timeout 2h;
+			proxy_send_timeout 2h;
 
 			# Pass authenticated username to backend
 			proxy_set_header X-Remote-User-Id $remote_user;


### PR DESCRIPTION
Nginx typical timeout on websocket is 60s. The solution usually is to send a ping between client and server every now and then. In clapshot this doesn't happen so here the timeout on nginx's ws proxy is increased from 60s to 600s.

See http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout for further details.