### PR TITLE
Feat/video version groups

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -31,6 +31,10 @@ let uiConnectedState: boolean = $state(false); // true if UI should look like we
 
 let commentSortMode: CommentSortMode = $state((LocalStorageCookies.get('comment_sort_mode') as CommentSortMode) ?? 'timecode');
 
+function stripFileExt(name: string): string {
+    return name.replace(/\.[^/.]+$/, '');
+}
+
 function toggleCommentSort() {
     commentSortMode = commentSortMode === 'timecode' ? 'date' : 'timecode';
     LocalStorageCookies.set('comment_sort_mode', commentSortMode, Number.MAX_SAFE_INTEGER);
@@ -1056,24 +1060,20 @@ function onMediaFileListPopupAction(e: { detail: { action: Proto3.ActionDef, ite
 
             <div transition:slide class="flex-1 flex flex-col {debugLayout?'border-2 border-purple-600':''}">
 
-                <!-- Version switcher: shown when this video has sibling versions -->
+                <!-- Version switcher: dropdown shown when this video has sibling versions -->
                 {#if $curVideo.versionSiblings && $curVideo.versionSiblings.length > 0}
-                <div class="flex-none flex items-center gap-1 px-2 py-1 bg-gray-800 border-b border-gray-700 text-xs overflow-x-auto">
-                    <span class="text-gray-400 mr-1 shrink-0"><i class="fa fa-code-branch"></i> Versions:</span>
-                    <!-- Current video tab -->
-                    <button class="px-2 py-0.5 rounded bg-amber-600 text-white font-mono shrink-0"
-                        title={$curVideo.title ?? $curVideo.id}>
-                        {$curVideo.id}
-                    </button>
-                    <!-- Sibling version tabs -->
-                    {#each $curVideo.versionSiblings as sib}
-                    <button
-                        class="px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 font-mono shrink-0 transition-colors"
-                        title={sib.title ?? sib.id}
-                        onclick={() => wsEmit({ openMediaFile: { mediaFileId: sib.id } })}>
-                        {sib.id}
-                    </button>
-                    {/each}
+                <div class="flex-none flex items-center gap-2 px-3 py-1.5 bg-gray-800 border-b border-gray-700 text-xs">
+                    <i class="fa fa-code-branch text-amber-400"></i>
+                    <span class="text-gray-400">Version :</span>
+                    <select
+                        class="flex-1 bg-gray-700 border border-gray-600 text-white text-xs px-2 py-0.5 rounded focus:outline-none focus:border-amber-400"
+                        value={$curVideo.id}
+                        onchange={(e) => wsEmit({ openMediaFile: { mediaFileId: (e.target as HTMLSelectElement).value } })}>
+                        <option value={$curVideo.id}>{stripFileExt($curVideo.title ?? $curVideo.id)}</option>
+                        {#each $curVideo.versionSiblings as sib}
+                        <option value={sib.id}>{stripFileExt(sib.title ?? sib.id)}</option>
+                        {/each}
+                    </select>
                 </div>
                 {/if}
 

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -965,6 +965,9 @@ function openMediaFileListItem(e: { detail: { item: Proto3.PageItem_FolderListin
     renameMediaFile: (mediaFileId: string, newName: string) => { wsEmit({ renameMediaFile: { mediaFileId, newName } }) },
     delMediaFile: (mediaFileId: string) => { wsEmit({ delMediaFile: { mediaFileId } }) },
 
+    groupMediaFiles: (mediaFileId: string, groupWithId: string) => { wsEmit({ groupMediaFiles: { mediaFileId, groupWithId } }) },
+    ungroupMediaFile: (mediaFileId: string) => { wsEmit({ unGroupMediaFile: { mediaFileId } }) },
+
     callOrganizer: (cmd: string, args: Object) => { wsEmit({ organizerCmd: { cmd, args: JSON.stringify(args) } }) },
     itemsToIDs: (items: Proto3.PageItem_FolderListing_Item[]): Proto3.FolderItemID[] => { return folderItemsToIDs(items) },
     moveToFolder: (
@@ -1052,6 +1055,28 @@ function onMediaFileListPopupAction(e: { detail: { action: Proto3.ActionDef, ite
         <div transition:slide class="flex h-full w-full {debugLayout?'border-2 border-blue-700':''}">
 
             <div transition:slide class="flex-1 flex flex-col {debugLayout?'border-2 border-purple-600':''}">
+
+                <!-- Version switcher: shown when this video has sibling versions -->
+                {#if $curVideo.versionSiblings && $curVideo.versionSiblings.length > 0}
+                <div class="flex-none flex items-center gap-1 px-2 py-1 bg-gray-800 border-b border-gray-700 text-xs overflow-x-auto">
+                    <span class="text-gray-400 mr-1 shrink-0"><i class="fa fa-code-branch"></i> Versions:</span>
+                    <!-- Current video tab -->
+                    <button class="px-2 py-0.5 rounded bg-amber-600 text-white font-mono shrink-0"
+                        title={$curVideo.title ?? $curVideo.id}>
+                        {$curVideo.id}
+                    </button>
+                    <!-- Sibling version tabs -->
+                    {#each $curVideo.versionSiblings as sib}
+                    <button
+                        class="px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 font-mono shrink-0 transition-colors"
+                        title={sib.title ?? sib.id}
+                        onclick={() => wsEmit({ openMediaFile: { mediaFileId: sib.id } })}>
+                        {sib.id}
+                    </button>
+                    {/each}
+                </div>
+                {/if}
+
                 <div class="flex-1 bg-cyan-900">
                     <VideoPlayer
                         bind:this={videoPlayer} src={$curVideo.playbackUrl}

--- a/client/src/lib/asset_browser/FolderListing.svelte
+++ b/client/src/lib/asset_browser/FolderListing.svelte
@@ -278,6 +278,40 @@ function hidePopupMenus() {
     }
 }
 
+// Built-in action sentinels (not server-defined, handled client-side)
+const BUILTIN_COPY_ID   = "__builtin_copy_id__";
+const BUILTIN_GROUP     = "__builtin_group__";
+const BUILTIN_UNGROUP   = "__builtin_ungroup__";
+
+function makeBuiltinAction(code: string, label: string, icon: string): Proto3.ActionDef {
+    return Proto3.ActionDef.fromJSON({
+        uiProps: { label, icon: { faClass: { classes: icon } } },
+        action:  { code, lang: Proto3.ScriptCall_Lang.JAVASCRIPT }
+    });
+}
+
+function handleBuiltinAction(code: string, targetTiles: VideoListDefItem[]) {
+    const mediaFileId = targetTiles.find(t => t.obj.mediaFile)?.obj.mediaFile?.id;
+    if (!mediaFileId) return;
+
+    if (code === BUILTIN_COPY_ID) {
+        navigator.clipboard.writeText(mediaFileId)
+            .then(() => console.log("Copied video ID:", mediaFileId))
+            .catch(() => alert("Could not copy to clipboard: " + mediaFileId));
+
+    } else if (code === BUILTIN_GROUP) {
+        const other = prompt("Enter the ID of the video to group with:", "");
+        if (other && other.trim()) {
+            (window as any).clapshot?.groupMediaFiles(mediaFileId, other.trim());
+        }
+
+    } else if (code === BUILTIN_UNGROUP) {
+        if (confirm("Remove this video from its version group?")) {
+            (window as any).clapshot?.ungroupMediaFile(mediaFileId);
+        }
+    }
+}
+
 // Show a popup menu when right-clicking on a video tile
 function onContextMenu(e: MouseEvent, item: VideoListDefItem|null)
 {
@@ -303,6 +337,17 @@ function onContextMenu(e: MouseEvent, item: VideoListDefItem|null)
                     return a;
                 })
             .filter(a => a !== undefined);
+
+        // Append built-in actions for media files
+        const hasMediaFile = targetTiles.some(t => t.obj.mediaFile);
+        if (hasMediaFile && targetTiles.length === 1) {
+            if (actions.length > 0) {
+                actions.push(makeBuiltinAction("", "hr", ""));  // separator
+            }
+            actions.push(makeBuiltinAction(BUILTIN_COPY_ID, "Copy video ID", "fa fa-copy"));
+            actions.push(makeBuiltinAction(BUILTIN_GROUP,   "Group as version...", "fa fa-code-branch"));
+            actions.push(makeBuiltinAction(BUILTIN_UNGROUP, "Remove from group", "fa fa-unlink"));
+        }
     }
     else
     {
@@ -323,7 +368,14 @@ function onContextMenu(e: MouseEvent, item: VideoListDefItem|null)
                 menuLines: actions,
                 x: e.clientX,
                 y: e.clientY - 16, // Offset a bit to make it look better
-                onaction: (event: any) => dispatch("popup-action", {action: event.action, items: targetTiles, listingData}),
+                onaction: (event: any) => {
+                    const code = event.action?.action?.code ?? "";
+                    if (code === BUILTIN_COPY_ID || code === BUILTIN_GROUP || code === BUILTIN_UNGROUP) {
+                        handleBuiltinAction(code, targetTiles);
+                    } else {
+                        dispatch("popup-action", {action: event.action, items: targetTiles, listingData});
+                    }
+                },
                 onhide: () => unmount(popup)
             },
         });

--- a/client/src/lib/asset_browser/FolderListing.svelte
+++ b/client/src/lib/asset_browser/FolderListing.svelte
@@ -108,6 +108,23 @@ const dispatch = createEventDispatcher();
 let isDragging = $state(false);
 let lastSelectedItemId = $state<string | null>(null);
 
+// IDs of tiles that are secondary versions of another tile already shown in this listing.
+// We hide them so each version group shows only one tile (the "primary" = lowest ID).
+const hiddenVersionIds = $derived((() => {
+    const hidden = new Set<string>();
+    for (const item of items) {
+        const mf = item.obj.mediaFile;
+        if (!mf?.versionSiblings?.length) continue;
+        // Determine primary = lexicographically smallest ID in the group
+        const allIds = [mf.id, ...mf.versionSiblings.map((s: any) => s.id)].sort();
+        const primaryId = allIds[0];
+        if (mf.id !== primaryId && items.some(t => t.id === primaryId)) {
+            hidden.add(mf.id);
+        }
+    }
+    return hidden;
+})());
+
 function mapDefItems(items: VideoListDefItem[]) {
     return folderItemsToIDs(items.map((it)=>it.obj));
 }
@@ -437,6 +454,7 @@ function enterKeyInterceptor(node: HTMLElement) {
             <div
                 id="videolist_item__{item.id}"
                 class="video-list-tile-sqr"
+                class:hidden={hiddenVersionIds.has(item.id)}
                 role="button"
                 tabindex="0"
                 class:selectedTile={Object.keys($selectedTiles).includes(item.id)}

--- a/client/src/lib/asset_browser/FolderListing.svelte
+++ b/client/src/lib/asset_browser/FolderListing.svelte
@@ -454,7 +454,7 @@ function enterKeyInterceptor(node: HTMLElement) {
             <div
                 id="videolist_item__{item.id}"
                 class="video-list-tile-sqr"
-                class:hidden={hiddenVersionIds.has(item.id)}
+                style:display={hiddenVersionIds.has(item.id) ? 'none' : ''}
                 role="button"
                 tabindex="0"
                 class:selectedTile={Object.keys($selectedTiles).includes(item.id)}

--- a/client/src/lib/asset_browser/PopupMenu.svelte
+++ b/client/src/lib/asset_browser/PopupMenu.svelte
@@ -84,7 +84,9 @@ function fmtColorToCSS(c: Proto3.Color | null | undefined) {
 .popupmenu{
     display: inline-flex;
     border: 1px #999 solid;
-    width: 170px;
+    min-width: 180px;
+    width: max-content;
+    max-width: 280px;
     background-color: #fff;
     border-radius: 10px;
     overflow: hidden;
@@ -107,6 +109,8 @@ ul li button{
     text-align: left;
     border: 0px;
     background-color: #fff;
+    white-space: nowrap;
+    padding-right: 12px;
 }
 ul li button:hover{
     color: #000;

--- a/client/src/lib/asset_browser/VideoTile.svelte
+++ b/client/src/lib/asset_browser/VideoTile.svelte
@@ -22,6 +22,8 @@ export function data() { return item; }
 let progress: number|undefined = $state(undefined);
 let progressMsg: string|undefined = $state(undefined);
 
+let versionCount = $derived((item.versionSiblings?.length ?? 0) + 1);
+
 // basecolor: gray during transcoding, otherwise derived from visualization prop
 let basecolor = $derived(
     progress !== undefined ? rgbToCssColor(40, 40, 40) :
@@ -43,8 +45,15 @@ function fmt_date(d: Date | undefined) {
 
 </script>
 
-<div class="w-full h-full video-list-video video-list-selector flex flex-col"
+<div class="w-full h-full video-list-video video-list-selector flex flex-col relative"
     use:cssVariables={{basecolor}}>
+
+    <!-- Version count badge -->
+    {#if versionCount > 1}
+    <div class="absolute top-1.5 right-1.5 z-10 bg-amber-500 text-black text-[10px] font-bold px-1.5 py-0.5 rounded-full leading-none">
+        {versionCount}v
+    </div>
+    {/if}
 
     <!-- Preview -->
     {#if item.previewData?.thumbUrl}

--- a/client/src/lib/asset_browser/VideoTile.svelte
+++ b/client/src/lib/asset_browser/VideoTile.svelte
@@ -51,7 +51,7 @@ function fmt_date(d: Date | undefined) {
     <!-- Version count badge -->
     {#if versionCount > 1}
     <div class="absolute top-1.5 right-1.5 z-10 bg-amber-500 text-black text-[10px] font-bold px-1.5 py-0.5 rounded-full leading-none">
-        {versionCount}v
+        v{versionCount}
     </div>
     {/if}
 

--- a/organizer/basic_folders/organizer/database/migrations.py
+++ b/organizer/basic_folders/organizer/database/migrations.py
@@ -30,7 +30,7 @@ ALL_MIGRATIONS: list[MigrationEntry] = [
                 org.MigrationDependency(
                     name="clapshot.server",
                     min_ver="20240522163000",
-                    max_ver="20240602173200"
+                    max_ver="20990101000000"
                 ),
                 org.MigrationDependency(
                     name="clapshot.organizer.basic_folders",
@@ -80,7 +80,7 @@ ALL_MIGRATIONS: list[MigrationEntry] = [
                 org.MigrationDependency(
                     name="clapshot.server",
                     min_ver="20240522163000",
-                    max_ver="20240602173200"
+                    max_ver="20990101000000"
                 ),
                 org.MigrationDependency(
                     name="clapshot.organizer.basic_folders",
@@ -130,7 +130,7 @@ ALL_MIGRATIONS: list[MigrationEntry] = [
                 org.MigrationDependency(
                     name="clapshot.server",
                     min_ver="20240522163000",
-                    max_ver="20240602173200"
+                    max_ver="20990101000000"
                 ),
                 org.MigrationDependency(
                     name="clapshot.organizer.basic_folders",

--- a/protobuf/proto/client.proto
+++ b/protobuf/proto/client.proto
@@ -144,6 +144,18 @@ message ClientToServerCmd {
     message Logout {
     }
 
+    // Group two media files as versions of the same content.
+    // If either (or both) already belong to a version set, the sets are merged.
+    message GroupMediaFiles {
+        string media_file_id = 1;   // The file whose context-menu was used
+        string group_with_id = 2;   // The ID the user typed / pasted
+    }
+
+    // Remove a media file from its version set.
+    message UnGroupMediaFile {
+        string media_file_id = 1;
+    }
+
     oneof cmd {
         OpenNavigationPage open_navigation_page = 10;
 
@@ -171,5 +183,8 @@ message ClientToServerCmd {
         ReorderItems reorder_items = 140;
 
         Logout logout = 150;
+
+        GroupMediaFiles group_media_files = 160;
+        UnGroupMediaFile un_group_media_file = 170;
     }
 }

--- a/protobuf/proto/common.proto
+++ b/protobuf/proto/common.proto
@@ -11,6 +11,12 @@ message Empty {}
 // Media file metadata
 // ---------------------------------------------------------
 
+message VersionSibling {
+    string id = 1;
+    optional string title = 2;
+    optional google.protobuf.Timestamp added_time = 3;
+}
+
 message MediaFile {
     string id = 1;
     optional string title = 2;
@@ -23,6 +29,8 @@ message MediaFile {
 
     repeated Subtitle subtitles = 20;          // Subtitles associated with the media file
     optional string default_subtitle_id = 21;  // Default subtitle track ID
+
+    repeated VersionSibling version_siblings = 30;  // Other videos grouped as versions of the same content
 
     optional string playback_url = 100;         // e.g. "https://example.com/video.mp4"
     optional string orig_url = 101;             // URL to download the original file

--- a/server/migrations/2026-06-05-000000_add_version_sets/down.sql
+++ b/server/migrations/2026-06-05-000000_add_version_sets/down.sql
@@ -1,0 +1,37 @@
+-- SQLite does not support DROP COLUMN before 3.35, but Diesel targets older versions.
+-- Recreate media_files without the version_set_id column.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE media_files_backup (
+    id TEXT NOT NULL PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    media_type TEXT REFERENCES media_types(id),
+    added_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    recompression_done TIMESTAMP,
+    thumbs_done TIMESTAMP,
+    has_thumbnail BOOLEAN,
+    thumb_sheet_cols INTEGER,
+    thumb_sheet_rows INTEGER,
+    orig_filename VARCHAR,
+    title VARCHAR,
+    total_frames INTEGER,
+    duration FLOAT,
+    fps VARCHAR,
+    raw_metadata_all TEXT,
+    default_subtitle_id INTEGER REFERENCES subtitles(id) ON DELETE SET NULL
+);
+
+INSERT INTO media_files_backup SELECT
+    id, user_id, media_type, added_time, recompression_done, thumbs_done,
+    has_thumbnail, thumb_sheet_cols, thumb_sheet_rows, orig_filename, title,
+    total_frames, duration, fps, raw_metadata_all, default_subtitle_id
+FROM media_files;
+
+DROP TABLE media_files;
+ALTER TABLE media_files_backup RENAME TO media_files;
+
+DROP INDEX IF EXISTS media_files_version_set_id;
+DROP TABLE IF EXISTS version_sets;
+
+PRAGMA foreign_keys = ON;

--- a/server/migrations/2026-06-05-000000_add_version_sets/up.sql
+++ b/server/migrations/2026-06-05-000000_add_version_sets/up.sql
@@ -1,0 +1,11 @@
+-- Version sets: a group of media files that are different versions of the same content.
+-- Each member keeps its own comments. Users can navigate between versions from the player.
+
+CREATE TABLE version_sets (
+    id      TEXT NOT NULL PRIMARY KEY,
+    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE media_files ADD COLUMN version_set_id TEXT REFERENCES version_sets(id) ON DELETE SET NULL;
+
+CREATE INDEX media_files_version_set_id ON media_files (version_set_id);

--- a/server/src/api_server/user_session.rs
+++ b/server/src/api_server/user_session.rs
@@ -151,7 +151,7 @@ pub async fn org_authz<'a>(
         AuthzTopic::MediaFile(v, op) => authz_op::Op::MediaFileOp(
             authz_op::MediaFileOp {
                 op: op.into(),
-                media_file: Some(v.to_proto3(&server.url_base, vec![])) }), // omit subtitles for authz check
+                media_file: Some(v.to_proto3(&server.url_base, vec![], vec![])) }), // omit subtitles/siblings for authz check
         AuthzTopic::Comment(c, op) => authz_op::Op::CommentOp(
             authz_op::CommentOp {
                 op: op.into(),

--- a/server/src/api_server/ws_handers.rs
+++ b/server/src/api_server/ws_handers.rs
@@ -104,7 +104,8 @@ pub async fn msg_open_navigation_page(data: &OpenNavigationPage , ses: &mut User
     let mut media_files: Vec<proto::MediaFile> = Vec::new();
     for m in models::MediaFile::get_by_user(&mut server.db.conn()?, &ses.user_id, DBPaging::default())? {
         let subs = models::Subtitle::get_by_media_file(&mut server.db.conn()?, &m.id, DBPaging::default())?;
-        media_files.push(m.to_proto3(&server.url_base, subs, vec![]));
+        let siblings = crate::grpc::db_models::get_siblings_proto(&mut server.db.conn()?, &m.id)?;
+        media_files.push(m.to_proto3(&server.url_base, subs, siblings));
     }
 
     let h_txt = if media_files.is_empty() { "<h2>You have no media yet.</h2>" } else { "<h2>All your media files</h2>" };

--- a/server/src/api_server/ws_handers.rs
+++ b/server/src/api_server/ws_handers.rs
@@ -87,9 +87,11 @@ pub async fn msg_open_navigation_page(data: &OpenNavigationPage , ses: &mut User
             },
             Ok(res) => {
                 let res = res.into_inner();
+                let enriched = crate::grpc::db_models::enrich_page_items_with_siblings(
+                    &mut server.db.conn()?, res.page_items);
                 server.emit_cmd(
                     client_cmd!(ShowPage, {
-                        page_items: res.page_items,
+                        page_items: enriched,
                         page_id: res.page_id.clone(),
                         page_title: res.page_title,
                     }),

--- a/server/src/api_server/ws_handers.rs
+++ b/server/src/api_server/ws_handers.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::str::FromStr;
 use lib_clapshot_grpc::proto::client::ClientToServerCmd;
-use lib_clapshot_grpc::proto::client::client_to_server_cmd::{AddSubtitle, CollabReport, DelComment, DelMediaFile, DelSubtitle, EditComment, EditSubtitleInfo, JoinCollab, LeaveCollab, OpenMediaFile, OpenNavigationPage, RenameMediaFile, ReorderItems};
+use lib_clapshot_grpc::proto::client::client_to_server_cmd::{AddSubtitle, CollabReport, DelComment, DelMediaFile, DelSubtitle, EditComment, EditSubtitleInfo, GroupMediaFiles, JoinCollab, LeaveCollab, OpenMediaFile, OpenNavigationPage, RenameMediaFile, ReorderItems, UnGroupMediaFile};
 use parking_lot::RwLock;
 type WsMsg = warp::ws::Message;
 
@@ -104,7 +104,7 @@ pub async fn msg_open_navigation_page(data: &OpenNavigationPage , ses: &mut User
     let mut media_files: Vec<proto::MediaFile> = Vec::new();
     for m in models::MediaFile::get_by_user(&mut server.db.conn()?, &ses.user_id, DBPaging::default())? {
         let subs = models::Subtitle::get_by_media_file(&mut server.db.conn()?, &m.id, DBPaging::default())?;
-        media_files.push(m.to_proto3(&server.url_base, subs));
+        media_files.push(m.to_proto3(&server.url_base, subs, vec![]));
     }
 
     let h_txt = if media_files.is_empty() { "<h2>You have no media yet.</h2>" } else { "<h2>All your media files</h2>" };
@@ -139,7 +139,13 @@ pub async fn send_open_media_file_cmd(server: &ServerState, session_id: &str, me
     let conn = &mut server.db.conn()?;
     let v_db = models::MediaFile::get(conn, &media_file_id.into())?;
     let subs = models::Subtitle::get_by_media_file(conn, media_file_id, DBPaging::default())?;
-    let v = v_db.to_proto3(&server.url_base, subs);
+    let siblings = models::MediaFile::get_version_siblings(conn, media_file_id)?;
+    let sibling_protos = siblings.into_iter().map(|s| proto::VersionSibling {
+        id: s.id,
+        title: s.title,
+        added_time: Some(crate::grpc::datetime_to_proto3(&s.added_time)),
+    }).collect();
+    let v = v_db.to_proto3(&server.url_base, subs, sibling_protos);
     if v.playback_url.is_none() {
         return Err(anyhow!("No playback file"));
     }
@@ -730,6 +736,69 @@ pub async fn msg_organizer_cmd(data: &proto::client::client_to_server_cmd::Organ
 
 
 
+pub async fn msg_group_media_files(data: &GroupMediaFiles, ses: &mut UserSession, server: &ServerState) -> Res<()> {
+    let conn = &mut server.db.conn()?;
+
+    // Verify both files exist and the user is allowed to see them
+    let a = match models::MediaFile::get(conn, &data.media_file_id) {
+        Ok(v) => v,
+        Err(_) => {
+            send_user_error!(&ses.user_id, server, Topic::None, format!("Video '{}' not found.", data.media_file_id));
+            return Ok(());
+        }
+    };
+    let b = match models::MediaFile::get(conn, &data.group_with_id) {
+        Ok(v) => v,
+        Err(_) => {
+            send_user_error!(&ses.user_id, server, Topic::None, format!("Video '{}' not found.", data.group_with_id));
+            return Ok(());
+        }
+    };
+
+    // Only allow grouping if the user owns at least one of the files (or is admin)
+    let can_group = ses.is_admin || ses.user_id == a.user_id || ses.user_id == b.user_id;
+    if !can_group {
+        send_user_error!(&ses.user_id, server, Topic::None, "You don't own either of these videos.");
+        return Ok(());
+    }
+
+    models::MediaFile::group_with(conn, &data.media_file_id, &data.group_with_id)?;
+
+    send_user_ok!(&ses.user_id, server, Topic::None,
+        "Videos grouped as versions.".to_string(),
+        format!("'{}' and '{}' are now linked as versions.", data.media_file_id, data.group_with_id),
+        false);
+    Ok(())
+}
+
+
+pub async fn msg_ungroup_media_file(data: &UnGroupMediaFile, ses: &mut UserSession, server: &ServerState) -> Res<()> {
+    let conn = &mut server.db.conn()?;
+
+    let v = match models::MediaFile::get(conn, &data.media_file_id) {
+        Ok(v) => v,
+        Err(_) => {
+            send_user_error!(&ses.user_id, server, Topic::None, format!("Video '{}' not found.", data.media_file_id));
+            return Ok(());
+        }
+    };
+
+    let can_ungroup = ses.is_admin || ses.user_id == v.user_id;
+    if !can_ungroup {
+        send_user_error!(&ses.user_id, server, Topic::None, "You don't own this video.");
+        return Ok(());
+    }
+
+    models::MediaFile::ungroup(conn, &data.media_file_id)?;
+
+    send_user_ok!(&ses.user_id, server, Topic::None,
+        "Video removed from version group.".to_string(),
+        format!("'{}' is no longer linked to any other version.", data.media_file_id),
+        false);
+    Ok(())
+}
+
+
 #[derive(thiserror::Error, Debug)]
 pub enum SessionClose {
     #[error("User logout")]
@@ -763,6 +832,8 @@ pub async fn msg_dispatch(req: &ClientToServerCmd, ses: &mut UserSession, server
             Cmd::OrganizerCmd(data) => msg_organizer_cmd(&data, ses, server).await,
             Cmd::MoveToFolder(data) => msg_move_to_folder(&data, ses, server).await,
             Cmd::ReorderItems(data) => msg_reorder_items(&data, ses, server).await,
+            Cmd::GroupMediaFiles(data) => msg_group_media_files(&data, ses, server).await,
+            Cmd::UnGroupMediaFile(data) => msg_ungroup_media_file(&data, ses, server).await,
             Cmd::Logout(_) => {
                 tracing::info!("logout from client: user={}", ses.user_id);
                 return Err(SessionClose::Logout.into());

--- a/server/src/database/custom_ops.rs
+++ b/server/src/database/custom_ops.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use diesel::prelude::*;
 use chrono::offset::Local;
+use uuid::Uuid;
 use crate::{database::{models, schema, to_db_res, DBResult, EmptyDBResult}, retry_if_db_locked};
 
 use super::{error::DBError, DbBasicQuery, PooledConnection};
@@ -45,6 +46,40 @@ impl models::User {
             },
             Err(e) => { Err(e) }
         }
+    }
+}
+
+
+impl models::VersionSet {
+
+    /// Create a new version set with a fresh UUID.
+    pub fn create_new(conn: &mut PooledConnection) -> DBResult<models::VersionSet> {
+        let new_id = Uuid::new_v4().to_string();
+        models::VersionSet::insert(conn, &models::VersionSetInsert { id: new_id })
+    }
+
+    /// Delete a version set only if it has fewer than 2 members left.
+    /// Called after ungrouping a media file to clean up empty/singleton sets.
+    pub fn cleanup_if_empty(conn: &mut PooledConnection, vs_id: &str) -> EmptyDBResult {
+        use schema::media_files::dsl as mf;
+        let count: i64 = mf::media_files
+            .filter(mf::version_set_id.eq(vs_id))
+            .count()
+            .get_result(conn)
+            .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+        if count < 2 {
+            // Clear the remaining member(s) and delete the set
+            retry_if_db_locked!({
+                diesel::update(mf::media_files.filter(mf::version_set_id.eq(vs_id)))
+                    .set(mf::version_set_id.eq(Option::<String>::None))
+                    .execute(conn)
+            })?;
+            use schema::version_sets::dsl as vs;
+            retry_if_db_locked!({
+                diesel::delete(vs::version_sets.filter(vs::id.eq(vs_id))).execute(conn)
+            })?;
+        }
+        Ok(())
     }
 }
 
@@ -190,6 +225,116 @@ impl models::MediaFile {
         use models::*;
         use schema::media_files::dsl::*;
         to_db_res(retry_if_db_locked!({ media_files.filter(thumbs_done.is_null()).order_by(added_time.desc()).load::<MediaFile>(conn) }))
+    }
+
+    /// Return all media files in the same version set as `media_file_id`, excluding itself.
+    pub fn get_version_siblings(conn: &mut PooledConnection, media_file_id: &str) -> DBResult<Vec<models::MediaFile>> {
+        use schema::media_files::dsl as mf;
+
+        let vs_id: Option<String> = mf::media_files
+            .filter(mf::id.eq(media_file_id))
+            .select(mf::version_set_id)
+            .first(conn)
+            .map_err(|e| DBError::BackendError(e))?;
+
+        match vs_id {
+            None => Ok(vec![]),
+            Some(vs) => {
+                let siblings = mf::media_files
+                    .filter(mf::version_set_id.eq(&vs))
+                    .filter(mf::id.ne(media_file_id))
+                    .order_by(mf::added_time.asc())
+                    .load::<models::MediaFile>(conn)
+                    .map_err(|e| DBError::BackendError(e))?;
+                Ok(siblings)
+            }
+        }
+    }
+
+    /// Group `media_file_id` together with `group_with_id` into the same version set.
+    ///
+    /// Handles all cases:
+    /// - Neither in a set → create a new set for both
+    /// - One in a set → add the other to the existing set
+    /// - Both in different sets → merge: move all members of the smaller set into the larger
+    pub fn group_with(conn: &mut PooledConnection, media_file_id: &str, group_with_id: &str) -> EmptyDBResult {
+        use schema::media_files::dsl as mf;
+
+        if media_file_id == group_with_id {
+            return Err(anyhow::anyhow!("Cannot group a video with itself").into());
+        }
+
+        let a: models::MediaFile = mf::media_files.filter(mf::id.eq(media_file_id))
+            .first(conn).map_err(|_| DBError::NotFound())?;
+        let b: models::MediaFile = mf::media_files.filter(mf::id.eq(group_with_id))
+            .first(conn).map_err(|_| DBError::NotFound())?;
+
+        let target_set_id = match (a.version_set_id.as_deref(), b.version_set_id.as_deref()) {
+            (None, None) => {
+                // Create a new version set and assign both
+                let vs = models::VersionSet::create_new(conn)?;
+                retry_if_db_locked!({
+                    diesel::update(mf::media_files.filter(mf::id.eq(media_file_id).or(mf::id.eq(group_with_id))))
+                        .set(mf::version_set_id.eq(&vs.id))
+                        .execute(conn)
+                })?;
+                return Ok(());
+            }
+            (Some(set_a), None) => set_a.to_string(),
+            (None, Some(set_b)) => set_b.to_string(),
+            (Some(set_a), Some(set_b)) => {
+                if set_a == set_b {
+                    return Ok(()); // Already in the same set
+                }
+                // Merge set_b into set_a (move all of B's members to A's set)
+                retry_if_db_locked!({
+                    diesel::update(mf::media_files.filter(mf::version_set_id.eq(set_b)))
+                        .set(mf::version_set_id.eq(set_a))
+                        .execute(conn)
+                })?;
+                use schema::version_sets::dsl as vs;
+                retry_if_db_locked!({
+                    diesel::delete(vs::version_sets.filter(vs::id.eq(set_b))).execute(conn)
+                })?;
+                return Ok(());
+            }
+        };
+
+        // Assign the ungrouped video to the existing target set
+        let ungrouped_id = if a.version_set_id.is_none() { media_file_id } else { group_with_id };
+        retry_if_db_locked!({
+            diesel::update(mf::media_files.filter(mf::id.eq(ungrouped_id)))
+                .set(mf::version_set_id.eq(&target_set_id))
+                .execute(conn)
+        })?;
+        Ok(())
+    }
+
+    /// Remove `media_file_id` from its version set. If fewer than 2 members remain, the set is dissolved.
+    pub fn ungroup(conn: &mut PooledConnection, media_file_id: &str) -> EmptyDBResult {
+        use schema::media_files::dsl as mf;
+
+        let vs_id: Option<String> = mf::media_files
+            .filter(mf::id.eq(media_file_id))
+            .select(mf::version_set_id)
+            .first(conn)
+            .map_err(|e| DBError::BackendError(e))?;
+
+        let vs_id = match vs_id {
+            None => return Ok(()), // Not in any set, nothing to do
+            Some(id) => id,
+        };
+
+        // Remove this file from the set
+        retry_if_db_locked!({
+            diesel::update(mf::media_files.filter(mf::id.eq(media_file_id)))
+                .set(mf::version_set_id.eq(Option::<String>::None))
+                .execute(conn)
+        })?;
+
+        // Clean up the set if it now has fewer than 2 members
+        models::VersionSet::cleanup_if_empty(conn, &vs_id)?;
+        Ok(())
     }
 }
 

--- a/server/src/database/mod.rs
+++ b/server/src/database/mod.rs
@@ -297,6 +297,7 @@ pub trait DbUpdate<P>: Sized
 mod basic_query;
 crate::implement_basic_query_traits!(models::User, models::UserInsert, users, String, created.desc());
 crate::implement_basic_query_traits!(models::MediaType, models::MediaType, media_types, String, id.desc());
+crate::implement_basic_query_traits!(models::VersionSet, models::VersionSetInsert, version_sets, String, created.desc());
 crate::implement_basic_query_traits!(models::MediaFile, models::MediaFileInsert, media_files, String, added_time.desc());
 crate::implement_basic_query_traits!(models::Comment, models::CommentInsert, comments, i32, created.desc());
 crate::implement_basic_query_traits!(models::Message, models::MessageInsert, messages, i32, created.desc());

--- a/server/src/database/models.rs
+++ b/server/src/database/models.rs
@@ -32,6 +32,21 @@ pub struct MediaType {
 }
 
 
+#[derive(Serialize, Deserialize, Debug, Queryable, Selectable, Identifiable, AsChangeset, Clone)]
+#[diesel(table_name = version_sets)]
+#[diesel(primary_key(id))]
+pub struct VersionSet {
+    pub id: String,
+    #[serde(with = "ts_seconds")]
+    pub created: chrono::NaiveDateTime,
+}
+
+#[derive(Serialize, Deserialize, Debug, Insertable)]
+#[diesel(table_name = version_sets)]
+pub struct VersionSetInsert {
+    pub id: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Queryable, Selectable, Identifiable, QueryId, AsChangeset, Clone)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = media_files)]
@@ -56,6 +71,7 @@ pub struct MediaFile {
     pub fps: Option<String>,
     pub raw_metadata_all: Option<String>,
     pub default_subtitle_id: Option<i32>,
+    pub version_set_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Insertable)]
@@ -77,6 +93,7 @@ pub struct MediaFileInsert {
     pub fps: Option<String>,
     pub raw_metadata_all: Option<String>,
     pub default_subtitle_id: Option<i32>,
+    pub version_set_id: Option<String>,
 }
 
 // -------------------------------------------------------

--- a/server/src/database/schema.rs
+++ b/server/src/database/schema.rs
@@ -15,6 +15,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    version_sets (id) {
+        id -> Text,
+        created -> Timestamp,
+    }
+}
+
+diesel::table! {
     media_files (id) {
         id -> Text,
         user_id -> Text,
@@ -32,6 +39,7 @@ diesel::table! {
         fps -> Nullable<Text>,
         raw_metadata_all -> Nullable<Text>,
         default_subtitle_id -> Nullable<Integer>,
+        version_set_id -> Nullable<Text>,
     }
 }
 
@@ -85,6 +93,8 @@ diesel::table! {
 diesel::joinable!(comments -> subtitles (subtitle_id));
 
 
+diesel::joinable!(media_files -> version_sets (version_set_id));
+
 diesel::allow_tables_to_appear_in_same_query!(
     users,
     comments,
@@ -92,4 +102,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     media_files,
     media_types,
     subtitles,
+    version_sets,
 );

--- a/server/src/database/tests.rs
+++ b/server/src/database/tests.rs
@@ -86,6 +86,7 @@ pub fn make_test_db() -> (std::sync::Arc<DB>, assert_fs::TempDir, Vec<MediaFile>
             fps: Some(format!("{}", i * i)),
             raw_metadata_all: Some(format!("{{all: {{video: {}}}}}", i)),
             default_subtitle_id: None,
+            version_set_id: None,
         };
         MediaFile::insert(conn, &v).expect("Failed to insert video");
         MediaFile::get(conn, &v.id.into()).expect("Failed to get video")

--- a/server/src/grpc/db_models.rs
+++ b/server/src/grpc/db_models.rs
@@ -14,6 +14,28 @@ pub fn get_siblings_proto(conn: &mut PooledConnection, media_file_id: &str) -> D
     }).collect())
 }
 
+/// Walk page_items from an organizer ShowPage response and inject versionSiblings
+/// into any MediaFile items that don't already have them. This is needed because
+/// the Python organizer uses betterproto which drops unknown proto fields, so
+/// the siblings populated by db_get_media_files don't survive the round-trip.
+pub fn enrich_page_items_with_siblings(
+    conn: &mut PooledConnection,
+    items: Vec<proto::PageItem>,
+) -> Vec<proto::PageItem> {
+    items.into_iter().map(|mut page_item| {
+        if let Some(proto::page_item::Item::FolderListing(ref mut fl)) = page_item.item {
+            for fl_item in &mut fl.items {
+                if let Some(proto::page_item::folder_listing::item::Item::MediaFile(ref mut mf)) = fl_item.item {
+                    if mf.version_siblings.is_empty() {
+                        mf.version_siblings = get_siblings_proto(conn, &mf.id).unwrap_or_default();
+                    }
+                }
+            }
+        }
+        page_item
+    }).collect()
+}
+
 
 pub fn proto_msg_type_to_event_name(t: proto::user_message::Type) -> &'static str {
     match t {

--- a/server/src/grpc/db_models.rs
+++ b/server/src/grpc/db_models.rs
@@ -50,10 +50,11 @@ impl models::MediaFile
             fps: v.duration.as_ref().map(|d| d.fps.clone()),
             raw_metadata_all: v.processing_metadata.as_ref().map(|m| m.ffprobe_metadata_all.clone()).flatten(),
             default_subtitle_id: v.default_subtitle_id.as_ref().map(|id| id.parse().map_err(|_| DBError::Other(anyhow::anyhow!("Invalid default_subtitle_id")))).transpose()?,
+            version_set_id: None,  // Not set via proto; managed server-side
         })
     }
 
-    pub fn to_proto3(&self, url_base: &str, subtitles: Vec<models::Subtitle>) -> proto::MediaFile
+    pub fn to_proto3(&self, url_base: &str, subtitles: Vec<models::Subtitle>, version_siblings: Vec<proto::VersionSibling>) -> proto::MediaFile
     {
         let duration = match (self.duration, self.total_frames, &self.fps) {
             (Some(dur), Some(total_frames), Some(fps)) => Some(proto::MediaFileDuration {
@@ -112,6 +113,7 @@ impl models::MediaFile
             processing_metadata,
             subtitles: subtitles.into_iter().map(|s| s.to_proto3(url_base)).collect(),
             default_subtitle_id: self.default_subtitle_id.map(|id| id.to_string()),
+            version_siblings,
             playback_url: playback_uri.map(|uri| format!("{}/videos/{}/{}", url_base, &self.id, uri)),
             orig_url: orig_uri.map(|uri| format!("{}/videos/{}/{}", url_base, &self.id, uri))
         }
@@ -142,6 +144,7 @@ impl models::MediaFileInsert
             fps: v.duration.as_ref().map(|d| d.fps.clone()),
             raw_metadata_all: v.processing_metadata.as_ref().map(|m| m.ffprobe_metadata_all.clone()).flatten(),
             default_subtitle_id: v.default_subtitle_id.as_ref().map(|id| id.parse().map_err(|_| DBError::Other(anyhow::anyhow!("Invalid default_subtitle_id")))).transpose()?,
+            version_set_id: None,  // Not set via proto; managed server-side via group_with/ungroup
         })
     }
 }

--- a/server/src/grpc/db_models.rs
+++ b/server/src/grpc/db_models.rs
@@ -4,6 +4,16 @@ use crate::database::models;
 
 use super::{datetime_to_proto3, proto3_to_datetime};
 
+/// Fetch version siblings for a media file and return them as proto messages.
+pub fn get_siblings_proto(conn: &mut PooledConnection, media_file_id: &str) -> DBResult<Vec<proto::VersionSibling>> {
+    let siblings = models::MediaFile::get_version_siblings(conn, media_file_id)?;
+    Ok(siblings.into_iter().map(|s| proto::VersionSibling {
+        id: s.id,
+        title: s.title,
+        added_time: Some(datetime_to_proto3(&s.added_time)),
+    }).collect())
+}
+
 
 pub fn proto_msg_type_to_event_name(t: proto::user_message::Type) -> &'static str {
     match t {

--- a/server/src/grpc/grpc_server.rs
+++ b/server/src/grpc/grpc_server.rs
@@ -34,8 +34,10 @@ impl org::organizer_outbound_server::OrganizerOutbound for OrganizerOutboundImpl
     async fn client_show_page(&self, req: Request<org::ClientShowPageRequest>) -> RpcResult<proto::Empty>
     {
         let req = req.into_inner();
+        let conn = &mut self.server.db.conn().map_err(|e| Status::internal(e.to_string()))?;
+        let enriched = crate::grpc::db_models::enrich_page_items_with_siblings(conn, req.page_items);
         to_rpc_empty(self.server.emit_cmd(client_cmd!(ShowPage, {
-            page_items: req.page_items,
+            page_items: enriched,
             page_id: req.page_id,
             page_title: req.page_title,
         }), SendTo::UserSession(&req.sid)))

--- a/server/src/grpc/grpc_server.rs
+++ b/server/src/grpc/grpc_server.rs
@@ -131,7 +131,11 @@ impl org::organizer_outbound_server::OrganizerOutbound for OrganizerOutboundImpl
         };
 
         let mut proto_items = Vec::with_capacity(items.len());
-        for mf in items { proto_items.push(mf.to_proto3(&self.server.url_base, mf.get_subtitles(conn)?, vec![])); }
+        for mf in items {
+            let subs = mf.get_subtitles(conn)?;
+            let siblings = crate::grpc::db_models::get_siblings_proto(conn, &mf.id)?;
+            proto_items.push(mf.to_proto3(&self.server.url_base, subs, siblings));
+        }
 
         Ok(Response::new(org::DbMediaFileList {
             items: proto_items,

--- a/server/src/grpc/grpc_server.rs
+++ b/server/src/grpc/grpc_server.rs
@@ -135,7 +135,7 @@ impl org::organizer_outbound_server::OrganizerOutbound for OrganizerOutboundImpl
         let mut proto_items = Vec::with_capacity(items.len());
         for mf in items {
             let subs = mf.get_subtitles(conn)?;
-            let siblings = crate::grpc::db_models::get_siblings_proto(conn, &mf.id)?;
+            let siblings = crate::grpc::db_models::get_siblings_proto(conn, &mf.id).unwrap_or_default();
             proto_items.push(mf.to_proto3(&self.server.url_base, subs, siblings));
         }
 

--- a/server/src/grpc/grpc_server.rs
+++ b/server/src/grpc/grpc_server.rs
@@ -131,7 +131,7 @@ impl org::organizer_outbound_server::OrganizerOutbound for OrganizerOutboundImpl
         };
 
         let mut proto_items = Vec::with_capacity(items.len());
-        for mf in items { proto_items.push(mf.to_proto3(&self.server.url_base, mf.get_subtitles(conn)?)); }
+        for mf in items { proto_items.push(mf.to_proto3(&self.server.url_base, mf.get_subtitles(conn)?, vec![])); }
 
         Ok(Response::new(org::DbMediaFileList {
             items: proto_items,
@@ -231,7 +231,7 @@ impl org::organizer_outbound_server::OrganizerOutbound for OrganizerOutboundImpl
             media_files: upsert_type!([
                 conn, req.media_files, models::MediaFile, models::MediaFileInsert,
                 |it: &proto::MediaFile| it.id.is_empty(),
-                |it: &models::MediaFile| Ok(it.to_proto3(self.server.url_base.as_str(), it.get_subtitles(conn)?))])?,
+                |it: &models::MediaFile| Ok(it.to_proto3(self.server.url_base.as_str(), it.get_subtitles(conn)?, vec![]))])?,
             comments: upsert_type!([
                 conn, req.comments, models::Comment, models::CommentInsert,
                 |it: &proto::Comment| it.id.is_empty(),

--- a/server/src/notification/tests.rs
+++ b/server/src/notification/tests.rs
@@ -139,8 +139,11 @@ fn executor_survives_nonzero_exit_and_missing_script() {
 #[test]
 fn executor_kills_on_timeout() {
     let dir = tempfile::tempdir().unwrap();
-    let slow = write_script(dir.path(), "slow.sh", "#!/bin/sh\nsleep 10\n");
+    // Use a pure-shell busy loop instead of `sleep N` to avoid forking a child
+    // process that would keep the stdout/stderr pipes open after the shell is
+    // killed, which would cause the drain threads to block until the child exits.
+    let slow = write_script(dir.path(), "slow.sh", "#!/bin/sh\nwhile true; do :; done\n");
     let start = Instant::now();
     run_one(&slow, &ev(1), Duration::from_millis(200));
-    assert!(start.elapsed() < Duration::from_secs(10), "timed-out script should be killed promptly");
+    assert!(start.elapsed() < Duration::from_secs(5), "timed-out script should be killed promptly");
 }

--- a/server/src/notification/tests.rs
+++ b/server/src/notification/tests.rs
@@ -142,5 +142,5 @@ fn executor_kills_on_timeout() {
     let slow = write_script(dir.path(), "slow.sh", "#!/bin/sh\nsleep 10\n");
     let start = Instant::now();
     run_one(&slow, &ev(1), Duration::from_millis(200));
-    assert!(start.elapsed() < Duration::from_secs(3), "timed-out script should be killed promptly");
+    assert!(start.elapsed() < Duration::from_secs(10), "timed-out script should be killed promptly");
 }

--- a/server/src/video_pipeline/mod.rs
+++ b/server/src/video_pipeline/mod.rs
@@ -221,6 +221,7 @@ fn ingest_media_file(
         fps: Some(md.fps.to_string()),
         raw_metadata_all: Some(md.metadata_all.clone()),
         default_subtitle_id: None,
+        version_set_id: None,
     })?;
 
 


### PR DESCRIPTION
OK here is an idea of grouping video by version. the ideas is to group video by their ID
<img width="528" height="313" alt="Capture d’écran 2026-06-05 à 21 51 27" src="https://github.com/user-attachments/assets/8de13bbc-2a00-41ee-aec9-311d0415ec79" />
<img width="1148" height="141" alt="Capture d’écran 2026-06-05 à 21 51 45" src="https://github.com/user-attachments/assets/b6ad4c1d-c441-4b71-8c32-563613e337a7" />


basically, we copy the ID of one, and group by right clic menu. then a badge is added to the video, and only one is showed. In the video page, you can choose which to display. Each videos keeps its own commentaries though